### PR TITLE
added missing typecast

### DIFF
--- a/src/com/google/android/maps/Overlay.java
+++ b/src/com/google/android/maps/Overlay.java
@@ -106,7 +106,7 @@ public class Overlay extends org.osmdroid.views.overlay.Overlay {
 	@Override
 	public boolean onSingleTapConfirmed(MotionEvent e, org.osmdroid.views.MapView mapView) {
 		if (mapView instanceof MapView.WrappedMapView)
-			return onTap(new GeoPoint(mapView.getProjection().fromPixels(e.getX(), e.getY())), ((MapView.WrappedMapView) mapView).getOriginal());
+			return onTap(new GeoPoint(mapView.getProjection().fromPixels((int)e.getX(), (int)e.getY())), ((MapView.WrappedMapView) mapView).getOriginal());
 		return false;
 	}
 


### PR DESCRIPTION
```
frameworks/mapsv1/src/com/google/android/maps/Overlay.java:109: error: no suitable method found for fromPixels(float,float)
            return onTap(new GeoPoint(mapView.getProjection().fromPixels(e.getX(), e.getY())), ((MapView.WrappedMapView) mapView).getOriginal());
                                                             ^
    method Projection.fromPixels(int,int,GeoPoint) is not applicable
      (actual and formal argument lists differ in length)
    method Projection.fromPixels(int,int) is not applicable
      (actual argument float cannot be converted to int by method invocation conversion)
```
